### PR TITLE
Make ToISBN work if the passed string is already a parsed ISBN

### DIFF
--- a/goisbn.go
+++ b/goisbn.go
@@ -121,10 +121,7 @@ func ToISBN(isbn string) (ISBN, error) {
 		return toisbn, err
 	}
 
-	if isbn != isn {
-		toisbn = ISBN(isn)
-	}
-
+	toisbn = ISBN(isn)
 	isbnLen := len(isn)
 
 	// ISBN 10

--- a/goisbn_test.go
+++ b/goisbn_test.go
@@ -246,7 +246,7 @@ func Test(t *testing.T) {
 		"What Are the Chances?: Voodoo Deaths, Office Gossip and Other Adventures in Probability": "0-8018-6941-2",
 		"Without Remorse":                        "0-00-647641-4",
 		"Wizard: Life and Times of Nikola Tesla": "0-8065-1960-6",
-		"Zero History":                           "978-0-670-91952-9"}
+		"Zero History":                           "9780670919529"}
 
 	// ToISBN
 	for _, val := range tests {


### PR DESCRIPTION
ToISBN was not storing the ISBN in this case.